### PR TITLE
Allow user-configurable retry delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,15 +69,27 @@ To initialize the SDK with AWS Credentials use the code below. Note, if you use 
 ```
 var apigClient = apigClientFactory.newClient({
     invokeUrl:'https://xxxxx.execute-api.us-east-1.amazonaws.com', // REQUIRED
-    accessKey: 'ACCESS_KEY', // REQUIRED
-    secretKey: 'SECRET_KEY', // REQUIRED
-    sessionToken: 'SESSION_TOKEN', //OPTIONAL: If you are using temporary credentials you must include the session token
-    region: 'eu-west-1', // REQUIRED: The region where the API is deployed.
-    systemClockOffset: 0, // OPTIONAL: An offset value in milliseconds to apply to signing time
-    retries: 4, // OPTIONAL: Number of times to retry before failing. Uses axon-retry plugin.
-    retryCondition: (err) => { // OPTIONAL: Callback to further control if request should be retried.  Uses axon-retry plugin.
-      return err.response && err.response.status === 500;
-    }
+    
+    region: 'eu-west-1',                                           // REQUIRED: The region where the API is deployed.
+    
+    accessKey: 'ACCESS_KEY',                                       // REQUIRED
+    
+    secretKey: 'SECRET_KEY',                                       // REQUIRED
+
+    sessionToken: 'SESSION_TOKEN',                                 // OPTIONAL: If you are using temporary credentials
+                                                                                you must include the session token.
+    
+    systemClockOffset: 0,                                          // OPTIONAL: An offset value in milliseconds to apply to signing time
+    
+    retries: 4,                                                    // OPTIONAL: Number of times to retry before failing. Uses axios-retry plugin.
+    
+    retryCondition: (err) => {                                     // OPTIONAL: Callback to further control if request should be retried.
+      return err.response && err.response.status === 500;          //           Uses axios-retry plugin.
+    },
+    
+    retryDelay: 100 || 'exponential' || (retryCount, error) => {   // OPTIONAL: Define delay (in ms) as a number, a callback, or
+      return retryCount * 100                                      //           'exponential' to use the in-built exponential backoff
+    }                                                              //           function. Uses axios-retry plugin. Default is no delay.
 });
 ```
 

--- a/src/apigClient.js
+++ b/src/apigClient.js
@@ -62,6 +62,7 @@ apigClientFactory.newClient = (config = {}) => {
     systemClockOffset: config.systemClockOffset,
     retries: config.retries,
     retryCondition: config.retryCondition,
+    retryDelay: config.retryDelay,
     host: config.host,
   };
 
@@ -81,6 +82,7 @@ apigClientFactory.newClient = (config = {}) => {
     defaultAcceptType: config.defaultAcceptType,
     retries: config.retries,
     retryCondition: config.retryCondition,
+    retryDelay: config.retryDelay,
     headers: config.headers,
   };
 

--- a/src/lib/apiGatewayCore/sigV4Client.js
+++ b/src/lib/apiGatewayCore/sigV4Client.js
@@ -155,6 +155,7 @@ sigV4ClientFactory.newClient = function(config) {
   awsSigV4Client.endpoint = utils.assertDefined(config.endpoint, 'endpoint');
   awsSigV4Client.retries = config.retries;
   awsSigV4Client.retryCondition = config.retryCondition;
+  awsSigV4Client.retryDelay = config.retryDelay;
   awsSigV4Client.host = config.host;
 
   awsSigV4Client.makeRequest = function(request) {
@@ -253,9 +254,21 @@ sigV4ClientFactory.newClient = function(config) {
     if (config.retries !== undefined) {
       signedRequest.baseURL = url;
       let client = axios.create(signedRequest);
+
+      // Allow user configurable delay, or built-in exponential delay
+      let retryDelay = function () { return 0 }
+      if (config.retryDelay === 'exponential') {
+        retryDelay = axiosRetry.exponentialDelay
+      } else if (typeof config.retryDelay === 'number') {
+        retryDelay = () => parseInt(config.retryDelay)
+      } else if (typeof config.retryDelay === 'function') {
+        retryDelay = config.retryDelay
+      }
+      
       axiosRetry(client, {
         retries: config.retries,
-        retryCondition: config.retryCondition
+        retryCondition: config.retryCondition,
+        retryDelay,
       });
       return client.request({method: verb});
     }

--- a/src/lib/apiGatewayCore/simpleHttpClient.js
+++ b/src/lib/apiGatewayCore/simpleHttpClient.js
@@ -79,9 +79,21 @@ simpleHttpClientFactory.newClient = (config) => {
     if (config.retries !== undefined) {
       simpleHttpRequest.baseURL = url;
       let client = axios.create(simpleHttpRequest);
+
+      // Allow user configurable delay, or built-in exponential delay
+      let retryDelay = () => 0
+      if (config.retryDelay === 'exponential') {
+        retryDelay = axiosRetry.exponentialDelay
+      } else if (typeof config.retryDelay === 'number') {
+        retryDelay = () => parseInt(config.retryDelay)
+      } else if (typeof config.retryDelay === 'function') {
+        retryDelay = config.retryDelay
+      }
+
       axiosRetry(client, {
         retries: config.retries,
-        retryCondition: config.retryCondition
+        retryCondition: config.retryCondition,
+        retryDelay,
       });
       return client.request({method: verb});
     }


### PR DESCRIPTION
The ability to auto-retry via axios-retry is great, but only having the default of _no delay_ makes that less useful than it ought to be.

This PR exposes the ability for the user to define their desired retry delay by specifying it either as:

- a number in milliseconds
- the string 'exponential', which will use the built-in exponential backoff method
- a callback function that returns the number of milliseconds to wait before the next retry